### PR TITLE
Fix file name case on example import

### DIFF
--- a/examples/app/main.js
+++ b/examples/app/main.js
@@ -3,6 +3,6 @@
  */
 import ReactDom from 'react-dom';
 import React from 'react';
-import App from './App';
+import App from './app';
 
 ReactDom.render(<App/>, document.getElementById("examples"));


### PR DESCRIPTION
I was unable to run the example on Linux until I fixed this.
